### PR TITLE
NAT: Support multiple tenants with overlapping address space (multiple context ids) share a single NAT pool.

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -58,9 +58,9 @@ add_vpp_plugin(vcdp
   vcdp_services/tcp-mss/tcp_mss.c
   vcdp_services/tcp-mss/node.c
 
-  vcdp_services/stats/api.c
-  vcdp_services/stats/stats.c
-  vcdp_services/stats/node.c
+  # vcdp_services/stats/api.c
+  # vcdp_services/stats/stats.c
+  # vcdp_services/stats/node.c
 
   API_FILES
   vcdp/vcdp_types.api

--- a/plugins/gateway/tunnel/node.h
+++ b/plugins/gateway/tunnel/node.h
@@ -156,7 +156,7 @@ vcdp_tunnel_input_node_inline(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_f
     }
 
     /* Store context_id as flow_id (to simplify the future lookup) */
-    b[0]->flow_id = tenant->context_id;
+    vcdp_buffer(b[0])->context_id = tenant->context_id;
 
     vlib_buffer_advance(b[0], bytes_to_inner_ip);
     vcdp_buffer(b[0])->tenant_index = *tenant_idx;

--- a/plugins/vcdp/cli.c
+++ b/plugins/vcdp/cli.c
@@ -220,6 +220,7 @@ vcdp_show_summary_command_fn(vlib_main_t *vm, unformat_input_t *input, vlib_cli_
   vec_foreach_index (thread_index, vcdp->per_thread_data) {
     ptd = vec_elt_at_index(vcdp->per_thread_data, thread_index);
     vlib_cli_output(vm, "Active sessions (%d): %d", thread_index, pool_elts(ptd->sessions));
+    vlib_cli_output(vm, "Expired vector length: %d", vec_len(ptd->expired_sessions));
   }
   vcdp_tenant_t *tenant;
   pool_foreach(tenant, vcdp->tenants) {

--- a/plugins/vcdp/lookup/node.c
+++ b/plugins/vcdp/lookup/node.c
@@ -191,7 +191,18 @@ vcdp_create_session_v4(vcdp_main_t *vcdp, vcdp_per_thread_data_t *ptd, vcdp_tena
     return 2;
 
   pool_get(ptd->sessions, session);
+  session_version_t session_version = session->session_version;
+  clib_memset(session, 0, sizeof(*session));
+  session->session_version = session_version;
   session_idx = session - ptd->sessions;
+
+    // Is this session on the expiry queue?
+  u32 index = vec_search(ptd->expired_sessions, session_idx);
+  if (index != ~0) {
+    VCDP_DBG(2, "WARNING: Found session to be removed on the expired vector %d", session_idx);
+    vec_del1(ptd->expired_sessions, index);
+  }
+
   pseudo_flow_idx = (session_idx << 1);
   value = vcdp_session_mk_table_value(thread_index, pseudo_flow_idx);
   kv.key[0] = k->as_u64[0];
@@ -201,7 +212,7 @@ vcdp_create_session_v4(vcdp_main_t *vcdp, vcdp_per_thread_data_t *ptd, vcdp_tena
 
   if (clib_bihash_add_del_16_8(&vcdp->table4, &kv, 2)) {
     /* collision - previous packet created same entry */
-    clib_warning("session already exists collision");
+    VCDP_DBG(1, "session already exists collision %llx", value);
     pool_put(ptd->sessions, session);
     return 3;
   }
@@ -232,6 +243,8 @@ vcdp_create_session_v4(vcdp_main_t *vcdp, vcdp_per_thread_data_t *ptd, vcdp_tena
 
   vlib_increment_simple_counter(&vcdp->tenant_simple_ctr[VCDP_TENANT_COUNTER_CREATED], thread_index,
                                 tenant_idx, 1);
+  VCDP_DBG(3, "Creating session: %d %U %llx", session_idx, format_vcdp_session_key, k, session_id);
+
   return 0;
 }
 
@@ -292,6 +305,7 @@ vcdp_lookup_inline(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *fra
   sc = service_chain;
 
   while (n_left) {
+  again:
     // clib_memcpy_fast(&kv, k4, 16);
     b[0]->error = 0;
     clib_bihash_kv_16_8_t kv;
@@ -312,8 +326,6 @@ vcdp_lookup_inline(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *fra
       // - Session table is full
       // - Tenant has no-create flag
       // - Can't find key
-      // TODO: What about traffic not for VCDP?
-      // Some sort of policy lookup required? Unless no-create is set???
       if (no_create || sc[0] > VCDP_SERVICE_CHAIN_TCP) {
         // Not creating sessions for drop or icmp errors
         vcdp_buffer(b[0])->service_bitmap = VCDP_SERVICE_MASK(drop);
@@ -329,12 +341,6 @@ vcdp_lookup_inline(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *fra
       u16 tenant_idx = vcdp_buffer(b[0])->tenant_index;
       vcdp_tenant_t *tenant = vcdp_tenant_at_index(vcdp, tenant_idx);
 
-      // If local address => ip4-receive
-      // 
-#if 0
-      if (tenant->flags & VCDP_TENANT_FLAG_NO_CREATE)
-        return 2;
-#endif
       int rv = vcdp_create_session_v4(vcdp, ptd, tenant, tenant_idx, thread_index, time_now, k4, vcdp_buffer(b[0])->rx_id, lv, sc[0]);
       switch (rv) {
         case 1: // full
@@ -362,6 +368,7 @@ vcdp_lookup_inline(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *fra
       hit[0] = true;
       hit_count++;
     }
+
     // Figure out if this is local or remote thread
     u32 flow_thread_index = vcdp_thread_index_from_lookup(lv[0]);
     if (flow_thread_index == thread_index) {
@@ -373,14 +380,12 @@ vcdp_lookup_inline(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *fra
       b[0]->flow_id = flow_index;
 
       session = vcdp_session_at_index(ptd, session_index);
-      if (session->state != VCDP_SESSION_STATE_STATIC && session->timer.next_expiration - time_now < 1) {
-        // Received a packet against an expired session. Let's restart the timer to avoid the session being deleted
-        // underneath us.
-        u16 tenant_idx = vcdp_buffer(b[0])->tenant_index;
-        vcdp_tenant_t *tenant = vcdp_tenant_at_index(vcdp, tenant_idx);
-
-        vcdp_session_timer_start(&ptd->wheel, &session->timer, session_index, time_now,
-                                 tenant->timeouts[VCDP_TIMEOUT_EMBRYONIC]);
+      if (vcdp_session_is_expired(session, time_now)) {
+        // Received a packet against an expired session. Recycle the session.
+        clib_warning("Expired session: %u %U %.02f %.02f (%.02f)", session_index, format_vcdp_session_key, k4,
+                     session->timer.next_expiration, time_now, session->timer.next_expiration - time_now);
+        vcdp_session_remove(vcdp, ptd, session, thread_index, session_index);
+        goto again;
       }
       u32 pbmp = session->bitmaps[vcdp_direction_from_flow_index(flow_index)];
 
@@ -527,6 +532,18 @@ VLIB_NODE_FN(vcdp_handoff_node)
         b[0]->error = node->errors[VCDP_HANDOFF_ERROR_NO_SESSION];
         goto next;
     }
+
+    // Check if session has expired. If so send it back to the lookup node to be created.
+    if (vcdp_session_is_expired(session, time_now)) {
+      VCDP_DBG(2, "Forwarding against expired handoff session, deleting and recreating %d", session_index);
+      vcdp_session_remove(vcdp, ptd, session, thread_index, session_index);
+
+      // TODO: NOT YET IMPLEMENTED. DROP FOR NOW
+      vcdp_buffer(b[0])->service_bitmap = VCDP_SERVICE_MASK(drop);
+      b[0]->error = node->errors[VCDP_HANDOFF_ERROR_NO_SESSION];
+      goto next;
+    }
+
     u32 pbmp = session->bitmaps[vcdp_direction_from_flow_index(flow_index)];
     vcdp_buffer(b[0])->service_bitmap = pbmp;
   next:
@@ -611,8 +628,11 @@ VLIB_NODE_FN(vcdp_session_expire_node)
 
   for (int i=0; vec_len(ptd->expired_sessions) > 0 && i < 256; i++) {
     session_index = vec_pop(ptd->expired_sessions);
+    VCDP_DBG(2, "Timer fired for session %u", session_index);
     vcdp_session_remove_or_rearm(vcdp, ptd, thread_index, session_index);
   }
+  if (vec_len(ptd->expired_sessions) > 0)
+    VCDP_DBG(2, "Expired sessions after cleanup: %d", vec_len(ptd->expired_sessions));
   return 0;
 }
 

--- a/plugins/vcdp/timer.h
+++ b/plugins/vcdp/timer.h
@@ -13,7 +13,7 @@ typedef struct {
   u32 handle;
 } vcdp_session_timer_t;
 
-/* Default NAT state protocol timeouts */
+/* Default session state protocol timeouts */
 #define foreach_vcdp_timeout                                                                                           \
   _(EMBRYONIC, 5, "embryonic")                                                                                         \
   _(ESTABLISHED, 240, "established")                                                                                   \
@@ -63,7 +63,8 @@ vcdp_session_timer_update(vcdp_tw_t *tw, vcdp_session_timer_t *timer, f64 now, u
 static_always_inline void
 vcdp_session_timer_update_maybe_past(vcdp_tw_t *tw, vcdp_session_timer_t *timer, u32 session_index, f64 now, u32 ticks)
 {
-    if (tw_timer_handle_is_free_2t_1w_2048sl(tw, timer->handle)) {
+    ASSERT(ticks>0);
+    if (tw_timer_handle_is_free_2t_1w_2048sl(tw, timer->handle) || timer->handle == ~0) {
       // restart timer
       vcdp_session_timer_start(tw, timer, session_index, now, ticks);
     } else {
@@ -80,6 +81,5 @@ vcdp_session_timer_running(vcdp_tw_t *tw, vcdp_session_timer_t *timer)
     return false;
   return true;
 }
-
 
 #endif

--- a/plugins/vcdp/timer.h
+++ b/plugins/vcdp/timer.h
@@ -4,9 +4,9 @@
 #ifndef included_vcdp_timer_h
 #define included_vcdp_timer_h
 
-#include <vppinfra/tw_timer_2t_1w_2048sl.h>
+#include <vppinfra/tw_timer_1t_3w_1024sl_ov.h>
 #include <vppinfra/vec.h>
-typedef tw_timer_wheel_2t_1w_2048sl_t vcdp_tw_t;
+typedef tw_timer_wheel_1t_3w_1024sl_ov_t vcdp_tw_t;
 
 typedef struct {
   f64 next_expiration;
@@ -28,17 +28,17 @@ typedef enum {
     VCDP_N_TIMEOUT
 } vcdp_timeout_type_t;
 
-#define vcdp_timer_start_internal  tw_timer_start_2t_1w_2048sl
-#define vcdp_timer_stop_internal   tw_timer_stop_2t_1w_2048sl
-#define vcdp_timer_update_internal tw_timer_update_2t_1w_2048sl
-#define vcdp_expire_timers         tw_timer_expire_timers_2t_1w_2048sl
-#define VCDP_TIMER_SI_MASK         (0x7fffffff)
+#define vcdp_timer_start_internal  tw_timer_start_1t_3w_1024sl_ov
+#define vcdp_timer_stop_internal   tw_timer_stop_1t_3w_1024sl_ov
+#define vcdp_timer_update_internal tw_timer_update_1t_3w_1024sl_ov
+#define vcdp_expire_timers         tw_timer_expire_timers_1t_3w_1024sl_ov
+// #define VCDP_TIMER_SI_MASK         (0x7fffffff)
 #define VCDP_TIMER_INTERVAL        ((f64) 1.0) /*in seconds*/
 
 static_always_inline void
 vcdp_tw_init(vcdp_tw_t *tw, void *expired_timer_callback, f64 timer_interval, u32 max_expirations)
 {
-  tw_timer_wheel_init_2t_1w_2048sl(tw, expired_timer_callback, timer_interval, max_expirations);
+  tw_timer_wheel_init_1t_3w_1024sl_ov(tw, expired_timer_callback, timer_interval, max_expirations);
 }
 
 static_always_inline void
@@ -64,7 +64,7 @@ static_always_inline void
 vcdp_session_timer_update_maybe_past(vcdp_tw_t *tw, vcdp_session_timer_t *timer, u32 session_index, f64 now, u32 ticks)
 {
     ASSERT(ticks>0);
-    if (tw_timer_handle_is_free_2t_1w_2048sl(tw, timer->handle) || timer->handle == ~0) {
+    if (tw_timer_handle_is_free_1t_3w_1024sl_ov(tw, timer->handle) || timer->handle == ~0) {
       // restart timer
       vcdp_session_timer_start(tw, timer, session_index, now, ticks);
     } else {

--- a/plugins/vcdp/vcdp.c
+++ b/plugins/vcdp/vcdp.c
@@ -41,6 +41,7 @@ vcdp_timer_expired(u32 *expired)
     u32 session_idx = e[0] & VCDP_TIMER_SI_MASK;
     if (pool_is_free_index(ptd->sessions, session_idx)) {
       /* Session has already been deleted */
+      VCDP_DBG(1, "session %u already deleted", session_idx);
       continue;
     }
     vec_add1(ptd->expired_sessions, session_idx);

--- a/plugins/vcdp/vcdp.c
+++ b/plugins/vcdp/vcdp.c
@@ -30,15 +30,18 @@ VCDP_SERVICE_DECLARE(drop)
 vcdp_main_t vcdp_main;
 vcdp_cfg_main_t vcdp_cfg_main;
 
+/*
+ * Schedule sessions for garbage collection
+ */
 static void
 vcdp_timer_expired(u32 *expired)
 {
-  u32 *e;
   uword thread_index = vlib_get_thread_index();
   vcdp_main_t *vcdp = &vcdp_main;
   vcdp_per_thread_data_t *ptd = vec_elt_at_index(vcdp->per_thread_data, thread_index);
-  vec_foreach (e, expired) {
-    u32 session_idx = e[0] & VCDP_TIMER_SI_MASK;
+  int i;
+  for (i = 0; i < vec_len(expired); i++) {
+    u32 session_idx = expired[i];
     if (pool_is_free_index(ptd->sessions, session_idx)) {
       /* Session has already been deleted */
       VCDP_DBG(1, "session %u already deleted", session_idx);

--- a/plugins/vcdp/vcdp.h
+++ b/plugins/vcdp/vcdp.h
@@ -20,7 +20,7 @@
 
 #include <vcdp/vcdp_counter.json.h>
 
-#define VCDP_DEBUG  99
+#define VCDP_DEBUG  0
 #if VCDP_DEBUG > 0
 #define VCDP_DBG(_lvl, _fmt, _args...)   \
   if (_lvl <= VCDP_DEBUG)                \

--- a/plugins/vcdp/vcdp.h
+++ b/plugins/vcdp/vcdp.h
@@ -15,7 +15,7 @@
 #include <vppinfra/bihash_16_8.h>
 #include <vppinfra/bihash_8_8.h>
 
-#include <vppinfra/tw_timer_2t_1w_2048sl.h>
+#include <vppinfra/tw_timer_1t_3w_1024sl_ov.h>
 #include <vppinfra/format_table.h>
 
 #include <vcdp/vcdp_counter.json.h>

--- a/plugins/vcdp/vcdp.h
+++ b/plugins/vcdp/vcdp.h
@@ -18,9 +18,18 @@
 #include <vppinfra/tw_timer_2t_1w_2048sl.h>
 #include <vppinfra/format_table.h>
 
-#include <vcdp/timer.h>
 #include <vcdp/vcdp_counter.json.h>
 
+#define VCDP_DEBUG  99
+#if VCDP_DEBUG > 0
+#define VCDP_DBG(_lvl, _fmt, _args...)   \
+  if (_lvl <= VCDP_DEBUG)                \
+    clib_warning (_fmt, ##_args)
+#else
+#define VCDP_DBG(_lvl, _fmt, _args...)
+#endif
+
+#include <vcdp/timer.h>
 
 // TODO: Make this configurable on startup
 #define VCDP_SESSION_ID_TOTAL_BITS    64

--- a/plugins/vcdp/vcdp_funcs.h
+++ b/plugins/vcdp/vcdp_funcs.h
@@ -76,15 +76,18 @@ vcdp_session_key_swap(vcdp_session_ip4_key_t *key)
 
 static_always_inline int
 vcdp_session_try_add_secondary_key(vcdp_main_t *vcdp, vcdp_per_thread_data_t *ptd, u32 thread_index,
-                                   u32 pseudo_flow_index, vcdp_session_ip4_key_t *key, u64 *h)
+                                   u32 pseudo_flow_index, vcdp_session_ip4_key_t *orgkey, u64 *h)
 {
   int rv;
   clib_bihash_kv_16_8_t kv;
   u64 value;
   vcdp_session_t *session;
   u32 session_index;
+
   value = vcdp_session_mk_table_value(thread_index, pseudo_flow_index);
 
+  // Ensure we don't change original key
+  vcdp_session_ip4_key_t _k = *orgkey, *key = &_k;
   vcdp_session_key_swap(key);
 
   kv.key[0] = key->as_u64[0];

--- a/plugins/vcdp/vcdp_funcs.h
+++ b/plugins/vcdp/vcdp_funcs.h
@@ -14,8 +14,18 @@ vcdp_session_remove(vcdp_main_t *vcdp, vcdp_per_thread_data_t *ptd, vcdp_session
   kv2.key = session->session_id;
 
   /* Stop timer if running */
+  VCDP_DBG(2, "Removing session %u %llx", session_index, session->session_id);
   if (vcdp_session_timer_running(&ptd->wheel, &session->timer)) {
+    VCDP_DBG(2, "Stopping timer for session %u", session_index);
     vcdp_session_timer_stop(&ptd->wheel, &session->timer);
+  }
+  session->timer.handle = ~0;
+
+  // Is this session on the expiry queue?
+  u32 index = vec_search(ptd->expired_sessions, session_index);
+  if (index != ~0) {
+    VCDP_DBG(1, "WARNING: Found session to be removed on expired vector %u", session_index);
+    vec_del1(ptd->expired_sessions, index);
   }
 
   if (session->key_flags & VCDP_SESSION_KEY_FLAG_PRIMARY_VALID_IP4) {
@@ -52,14 +62,19 @@ vcdp_session_remove_or_rearm(vcdp_main_t *vcdp, vcdp_per_thread_data_t *ptd, u32
   f64 diff = (session->timer.next_expiration - (ptd->current_time + VCDP_TIMER_INTERVAL)) / VCDP_TIMER_INTERVAL;
   if (diff > (f64) 1.) {
     /* Rearm the timer accordingly */
-    if (tw_timer_handle_is_free_2t_1w_2048sl(&ptd->wheel, session->timer.handle)) {
-      vcdp_session_timer_start(&ptd->wheel, &session->timer, session_index, ptd->current_time, diff);
-    } else {
-      vcdp_timer_update_internal(&ptd->wheel, session->timer.handle, diff);
-    }
+    VCDP_DBG(2, "Rearming timer for session %u Now: %.2f Ticks: %.2f %llx", session_index,
+             ptd->current_time, diff, session->session_id);
+    vcdp_session_timer_update_maybe_past(&ptd->wheel, &session->timer, session_index, ptd->current_time, diff);
   } else {
+    VCDP_DBG(2, "Removing session %u %llx", session_index, session->session_id);
     vcdp_session_remove(vcdp, ptd, session, thread_index, session_index);
   }
+}
+
+static_always_inline bool
+vcdp_session_is_expired(vcdp_session_t *session, f64 time_now)
+{
+  return (session->state != VCDP_SESSION_STATE_STATIC && session->timer.next_expiration - time_now < 1);
 }
 
 static void

--- a/plugins/vcdp_services/nat/api.c
+++ b/plugins/vcdp_services/nat/api.c
@@ -25,7 +25,7 @@ vl_api_vcdp_nat_add_t_handler(vl_api_vcdp_nat_add_t *mp)
   vec_resize(addrs, mp->n_addr);
   for (int i = 0; i < mp->n_addr; i++)
     ip4_address_decode(mp->addr[i], addrs + i);
-  int rv = vcdp_nat_add((char *)mp->nat_id, addrs, false);
+  int rv = vcdp_nat_add((char *)mp->nat_id, mp->context_id, addrs, false);
   vec_free(addrs);
   REPLY_MACRO_END(VL_API_VCDP_NAT_ADD_REPLY);
 }

--- a/plugins/vcdp_services/nat/cli.c
+++ b/plugins/vcdp_services/nat/cli.c
@@ -14,6 +14,7 @@ vcdp_nat_add_command_fn(vlib_main_t *vm, unformat_input_t *input, vlib_cli_comma
   u8 *nat_id = 0;
   u32 tenant_id = ~0;
   u32 sw_if_index = ~0;
+  u32 context_id = 0;
   int rv;
 
   if (!unformat_user(input, unformat_line_input, line_input))
@@ -23,6 +24,8 @@ vcdp_nat_add_command_fn(vlib_main_t *vm, unformat_input_t *input, vlib_cli_comma
     if (unformat(line_input, "id %s", &nat_id))
       ;
     if (unformat(line_input, "tenant %d", &tenant_id))
+      ;
+    else if (unformat(line_input, "context %d", &context_id))
       ;
     else if (unformat(line_input, "%U", unformat_ip4_address, &tmp))
       vec_add1(addr, tmp);
@@ -45,7 +48,7 @@ vcdp_nat_add_command_fn(vlib_main_t *vm, unformat_input_t *input, vlib_cli_comma
   } else if (sw_if_index != ~0) {
     rv = vcdp_nat_if_add((char *)nat_id, sw_if_index);
   } else {
-    rv = vcdp_nat_add((char *)nat_id, addr, false);
+    rv = vcdp_nat_add((char *)nat_id, context_id, addr, false);
   }
   if (rv != 0) {
     err = clib_error_return (0, "NAT instance command failed");

--- a/plugins/vcdp_services/nat/nat.api
+++ b/plugins/vcdp_services/nat/nat.api
@@ -11,6 +11,7 @@ autoreply autoendian define vcdp_nat_add
   u32 context;
 
   string nat_id[37]; // UUID
+  u32 context_id [default=0];
   u8 n_addr;
   vl_api_ip4_address_t addr[n_addr];
 };

--- a/plugins/vcdp_services/nat/nat.h
+++ b/plugins/vcdp_services/nat/nat.h
@@ -28,6 +28,7 @@ typedef struct {
 
 typedef struct {
   char nat_id[36+1];
+  u32 context_id;
   ip4_address_t *addresses; // vec
 } nat_instance_t;
 
@@ -94,7 +95,7 @@ extern nat_main_t nat_main;
 
 format_function_t format_vcdp_nat_rewrite;
 
-int vcdp_nat_add(char *natid, ip4_address_t *addr, bool is_if);
+int vcdp_nat_add(char *natid, u32 context_id, ip4_address_t *addr, bool is_if);
 int vcdp_nat_if_add(char *nat_id, u32 sw_if_index);
 int vcdp_nat_remove(char *nat_id);
 int vcdp_nat_bind_set_unset(u32 tenant_id, char *nat_id, bool is_set);

--- a/plugins/vcdp_services/nat/slowpath_node.c
+++ b/plugins/vcdp_services/nat/slowpath_node.c
@@ -85,7 +85,8 @@ nat_slow_path_process_one(vcdp_main_t *vcdp, vcdp_per_thread_data_t *vptd, /*u32
   if (PREDICT_FALSE(pool->num > NAT_ALLOC_POOL_ARRAY_SZ))
     ASSERT(0);
 #endif
-//  new_key.context_id = tenant->reverse_context;
+
+  new_key.context_id = instance->context_id;
 
   /* Allocate a new source */
   ip4_old_src_addr = *ip4_key_src_addr;
@@ -93,7 +94,7 @@ nat_slow_path_process_one(vcdp_main_t *vcdp, vcdp_per_thread_data_t *vptd, /*u32
   ip4_new_src_addr = instance->addresses[src_addr_index].as_u32;
   *ip4_key_src_addr = ip4_new_src_addr;
 
-  pseudo_flow_index = (session_index << 1) | 0x1; // TODO: Always 1, since this is always the return flow
+  pseudo_flow_index = (session_index << 1) | 0x1; // Always 1, since this is always the return flow
 
   /* Allocate a new port */
   ip4_key_src_port = &new_key.sport;
@@ -103,7 +104,6 @@ nat_slow_path_process_one(vcdp_main_t *vcdp, vcdp_per_thread_data_t *vptd, /*u32
   /* First try with original src port */
   ip4_new_port = ip4_old_port;
 
-  // TODO: The secondary key should be added by create session and modified by the NAT node?????
   while ((++n_retries) < VCDP_NAT_MAX_PORT_ALLOC_RETRIES &&
          vcdp_session_try_add_secondary_key(vcdp, vptd, thread_index, pseudo_flow_index, &new_key, &h)) {
     /* Use h to try a different port */

--- a/plugins/vcdp_services/tcp-check-lite/node.h
+++ b/plugins/vcdp_services/tcp-check-lite/node.h
@@ -94,6 +94,7 @@ update_state_one_pkt(vcdp_tw_t *tw, vcdp_tenant_t *tenant, vcdp_tcp_check_lite_s
     tcp_session->state = VCDP_TCP_CHECK_LITE_STATE_CLOSED;
     tcp_session->flags[VCDP_FLOW_FORWARD] = 0;
     tcp_session->flags[VCDP_FLOW_REVERSE] = 0;
+    next_timeout = tenant->timeouts[vcdp_tcp_state_to_timeout(tcp_session->state)];
   }
 
   u8 old_flags = tcp_session->flags[dir];

--- a/plugins/vcdp_services/tcp-check-lite/node.h
+++ b/plugins/vcdp_services/tcp-check-lite/node.h
@@ -77,8 +77,6 @@ update_state_one_pkt(vcdp_tw_t *tw, vcdp_tenant_t *tenant, vcdp_tcp_check_lite_s
   ip4_header_t *ip4 = (ip4_header_t *) vlib_buffer_get_current(b[0]);
   tcp_header_t *tcp = ip4_next_header(ip4);
 
-  sf[0] = nsf[0] = tcp_session->state;
-
   /* Ignore non first fragments */
   if (ip4_get_fragment_offset(ip4) > 0) {
     vcdp_next(b[0], to_next);
@@ -96,6 +94,7 @@ update_state_one_pkt(vcdp_tw_t *tw, vcdp_tenant_t *tenant, vcdp_tcp_check_lite_s
     tcp_session->flags[VCDP_FLOW_REVERSE] = 0;
     next_timeout = tenant->timeouts[vcdp_tcp_state_to_timeout(tcp_session->state)];
   }
+  sf[0] = nsf[0] = tcp_session->state;
 
   u8 old_flags = tcp_session->flags[dir];
   tcp_session->flags[dir] |= flags;
@@ -127,6 +126,7 @@ update_state_one_pkt(vcdp_tw_t *tw, vcdp_tenant_t *tenant, vcdp_tcp_check_lite_s
     }
     break;
   case VCDP_TCP_CHECK_LITE_STATE_CLOSING:
+#if 0
     // Allow a transitory session to reopen
     if ((tcp_session->flags[VCDP_FLOW_FORWARD] & tcp_session->flags[VCDP_FLOW_REVERSE]) ==
         (TCP_FLAG_ACK)) {
@@ -135,6 +135,7 @@ update_state_one_pkt(vcdp_tw_t *tw, vcdp_tenant_t *tenant, vcdp_tcp_check_lite_s
       next_timeout = tenant->timeouts[VCDP_TIMEOUT_TCP_ESTABLISHED];
       session->state = VCDP_SESSION_STATE_ESTABLISHED;
     }
+#endif
     break;
     default:
       clib_warning("Unknown state %d", old_state);

--- a/test/native/startup.conf
+++ b/test/native/startup.conf
@@ -28,5 +28,5 @@ vcdp {
 #}
 cpu {
   main-core 0
-  workers 2
+  workers 1
 }

--- a/test/test_nat.py
+++ b/test/test_nat.py
@@ -85,7 +85,8 @@ src_port = 12345        # Port number of the internal device
 dst_port = 80           # Port number of the external device
 
 inside_iface = 'tun0'
-outside_iface = 'underlay-tun0'
+# outside_iface = 'underlay-tun0'
+outside_iface = 'tun1'
 
 
 def send_and_receive(packet, src_iface, dst_iface, send_count=1):

--- a/test/test_nat.py
+++ b/test/test_nat.py
@@ -431,6 +431,14 @@ test_cases = [
         'expect': None,
     },
 
+    # test27: Create a unidirectional UDP session.
+    {
+        'name': 'unidirectional udp session',
+        'send': IP(src=src_ip, dst=dst_ip) / UDP(sport=src_port, dport=dst_port+100) / "Test NAT UDP data",
+        'expect': IP(src=nat_ip, dst=dst_ip) / UDP(sport=src_port, dport=dst_port+100) / "Test NAT UDP data",
+    },
+
+
     # Fragments / MTU
     # Hairpinning
 ]

--- a/test/test_nat.py
+++ b/test/test_nat.py
@@ -250,8 +250,8 @@ test_cases = [
     # test6: Create a UDP session.
     {
         'name': 'session created from udp_data',
-        'send': IP(src=src_ip, dst=dst_ip) / UDP(sport=src_port, dport=dst_port) / "Test NAT UDP data",
-        'expect': IP(src=nat_ip, dst=dst_ip) / UDP(sport=src_port, dport=dst_port) / "Test NAT UDP data",
+        'send': IP(src=src_ip, dst=dst_ip) / UDP(sport=src_port+6, dport=dst_port+6) / "Test NAT UDP data",
+        'expect': IP(src=nat_ip, dst=dst_ip) / UDP(sport=src_port+6, dport=dst_port+6) / "Test NAT UDP data",
         'validate_vpp': lambda vpp, packet, expected_state=0: validate_vpp_session_state(vpp, packet, expected_state)
     },
 


### PR DESCRIPTION
Change the API to tie a NAT pool to a particular context id.
If a tunnel is bound to the same context as another, if a packet with the same
5-tuple is sent on both tunnels, the same session is used so return traffic will
only go back on the first tunnel. No form of load balancing will happen.

If a tunnel belongs to a different context (via a different tenant), two separate
sessions (and a separate NAT mapping) will be created.

Signed-off-by: Ole Troan <otroan@employees.org>
